### PR TITLE
Check for null or whitespace in $oldDir

### DIFF
--- a/bucket/pdm.json
+++ b/bucket/pdm.json
@@ -17,8 +17,10 @@
     "uninstaller": {
         "script": [
             "$oldPath = [Environment]::GetEnvironmentVariable(\"PYTHONPATH\", [System.EnvironmentVariableTarget]::User)",
-            "$newPath = ($oldPath.Split(';') | Where { $_ -notlike \"$dir\\venv\\*\" }) -join ';'",
-            "[Environment]::SetEnvironmentVariable(\"PYTHONPATH\", $newPath, [System.EnvironmentVariableTarget]::User)"
+            "If (-not [string]::IsNullOrWhiteSpace($oldPath)) {",
+            "    $newPath = ($oldPath.Split(';') | Where { $_ -notlike \"$dir\\venv\\*\" }) -join ';'",
+            "    [Environment]::SetEnvironmentVariable(\"PYTHONPATH\", $newPath, [System.EnvironmentVariableTarget]::User)",
+            "}"
         ]
     },
     "checkver": {


### PR DESCRIPTION
Hi,

Sometimes the `PYTHONPATH` environment variable isn't set. Not sure how that happens, but when it's the case uninstalling or updating pdm in scoop fails. This PR fixes the uninstall script to check for the null and whitespace case.